### PR TITLE
Fixes for unit test coverage badges

### DIFF
--- a/.github/workflows/docs_pusher.yml
+++ b/.github/workflows/docs_pusher.yml
@@ -32,17 +32,5 @@ jobs:
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{secrets.GITHUB_TOKEN}}
         publish_dir: ./docs/doxygen/html
-
-    - name: Update README unit test coverage badge
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        BADGE_URL=$(./test/create_badge_url.sh -e)
-        sed -i -e "s/https:\/\/img\.shields\.io\/badge\/coverage-[0-9\.]\+%25-[a-z]\+/${BADGE_URL}/" ./README.md
-
-    - name: Push updated README
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: Updating README.md unit test coverage badge
-        file_pattern: README.md

--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        ref: ${{github.head_ref}}
+        token: ${{ secrets.PAT_TOKEN }}
         fetch-depth: 1
       
     # Annoyingly I can't find a PPA with the latest lcov, so I have to download
@@ -45,6 +47,18 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/test
         ./calculate_test_coverage.sh ${GITHUB_WORKSPACE}/../build_unit_tests
+
+    - name: Update README unit test coverage badge
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        BADGE_URL=$(./test/create_badge_url.sh -e)
+        sed -i -e "s/https:\/\/img\.shields\.io\/badge\/Unit_Test_Coverage-[0-9\.]\+%25-[a-z]\+/${BADGE_URL}/" ./README.md
+
+    - name: Push updated README and old_coverage
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Updating README.md unit test coverage badge
+        file_pattern: README.md test/old_coverage
 
   # Runs ASan, LSan, and UBSan on the code
   address_sanitizer:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Documentation Generator](https://github.com/cmannett85/malbolge/workflows/Documentation%20Generator/badge.svg) ![Release Builder](https://github.com/cmannett85/malbolge/workflows/Release%20Builder/badge.svg) ![Unit test coverage](https://img.shields.io/badge/coverage-00.0%25-red)
+![Documentation Generator](https://github.com/cmannett85/malbolge/workflows/Documentation%20Generator/badge.svg) ![Release Builder](https://github.com/cmannett85/malbolge/workflows/Release%20Builder/badge.svg) ![Unit test coverage](https://img.shields.io/badge/Unit_Test_Coverage-00.0%25-red)
 
 ---
 

--- a/test/create_badge_url.sh
+++ b/test/create_badge_url.sh
@@ -26,7 +26,7 @@ elif (( $(echo "$COVERAGE < 90" | bc -l) )); then
 fi
 
 if [ "$ESCAPE" == "0" ]; then
-    echo "https://img.shields.io/badge/coverage-${COVERAGE}%25-${COLOUR}"
+    echo "https://img.shields.io/badge/Unit_Test_Coverage-${COVERAGE}%25-${COLOUR}"
 else
-    echo "https:\/\/img\.shields\.io\/badge\/coverage-${COVERAGE}%25-${COLOUR}"
+    echo "https:\/\/img\.shields\.io\/badge\/Unit_Test_Coverage-${COVERAGE}%25-${COLOUR}"
 fi


### PR DESCRIPTION
The updated README and old_coverage is generated as a new commit in the PR (hopefully).